### PR TITLE
 Support async upload resolution via 'details' field

### DIFF
--- a/src/transifex_api/__init__.py
+++ b/src/transifex_api/__init__.py
@@ -84,8 +84,13 @@ class ResourceStringsAsyncUpload(jsonapi.Resource):
                     'title': e['detail'],
                     'status': '409'} for e in upload.errors]
                 raise JsonApiException(409, errors)
+
             if upload.redirect:
                 return upload.follow()
+            if (hasattr(upload, 'attributes')
+                    and upload.attributes.get("details")):
+                return upload.attributes.get("details")
+
             time.sleep(interval)
             upload.reload()
 
@@ -123,8 +128,13 @@ class ResourceTranslationsAsyncUpload(Resource):
                     'title': e['detail'],
                     'status': '409'} for e in upload.errors]
                 raise JsonApiException(409, errors)
+
             if upload.redirect:
                 return upload.follow()
+            if (hasattr(upload, 'attributes')
+                    and upload.attributes.get("details")):
+                return upload.attributes.get("details")
+
             time.sleep(interval)
             upload.reload()
 


### PR DESCRIPTION
Some async upload endpoints now do not respond with 303;
instead they include a 'details' field in a 200 response.
This field is not included while the upload is still pending.

With this change, both ways are supported.